### PR TITLE
Align repo with SWAIF SpecKit: add specs structure, canonical constitution, Copilot entry, Kanban workflow and stage runner

### DIFF
--- a/.github/ISSUE_TEMPLATE/swaif_feature.yml
+++ b/.github/ISSUE_TEMPLATE/swaif_feature.yml
@@ -1,0 +1,36 @@
+name: SWAIF Feature
+about: Factory Input Package for stage-gated SWAIF execution
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Submit a SWAIF Factory Input Package. Required headings are parsed by automation.
+  - type: input
+    id: feature_slug
+    attributes:
+      label: Feature Slug
+      description: Use kebab-case. Example: 001-clinic-billing
+      placeholder: 001-example-feature
+    validations:
+      required: true
+  - type: dropdown
+    id: declared_execution_type
+    attributes:
+      label: Declared Execution Type
+      options:
+        - Hands-On Run
+        - Research Experiment
+        - Prototype
+        - PoC
+        - MVP
+        - Scaled Product
+    validations:
+      required: true
+  - type: textarea
+    id: fip
+    attributes:
+      label: Factory Input Package
+      description: Provide business context, constraints, acceptance criteria, and non-goals.
+    validations:
+      required: true

--- a/.github/workflows/swaif-factory.yml
+++ b/.github/workflows/swaif-factory.yml
@@ -1,0 +1,195 @@
+name: SWAIF Factory
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: SWAIF stage to run
+        required: true
+        type: choice
+        options:
+          - specify
+          - plan
+          - tasks
+          - implement
+          - verify
+      feature_slug:
+        description: Feature slug (kebab-case)
+        required: true
+        type: string
+      declared_execution_type:
+        description: Declared Execution Type
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: swaif-factory-${{ github.event_name }}-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-stage:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' &&
+      (github.event.label.name == 'swaif:specify' ||
+       github.event.label.name == 'swaif:plan' ||
+       github.event.label.name == 'swaif:tasks' ||
+       github.event.label.name == 'swaif:implement' ||
+       github.event.label.name == 'swaif:verify'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve stage and metadata
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            let stage = '';
+            let featureSlug = '';
+            let executionType = '';
+            let issueNumber = '';
+            const allowedStages = new Set(['specify', 'plan', 'tasks', 'implement', 'verify']);
+
+            if (eventName === 'workflow_dispatch') {
+              stage = core.getInput('stage').trim();
+              featureSlug = core.getInput('feature_slug').trim();
+              executionType = core.getInput('declared_execution_type').trim();
+              issueNumber = '0';
+            } else {
+              const issue = context.payload.issue;
+              issueNumber = String(issue.number);
+              const label = context.payload.label?.name || '';
+              stage = label.replace('swaif:', '').trim();
+
+              const body = issue.body || '';
+              const readHeading = (heading) => {
+                const pattern = new RegExp(`^### ${heading}\\s*$\\n([\\s\\S]*?)(?=^### |$)`, 'm');
+                const match = body.match(pattern);
+                if (!match) return '';
+                const value = match[1]
+                  .split('\n')
+                  .map((line) => line.trim())
+                  .find((line) => line.length > 0 && line !== '_No response_');
+                return value || '';
+              };
+
+              featureSlug = readHeading('Feature Slug');
+              executionType = readHeading('Declared Execution Type');
+
+              if (!featureSlug || !executionType) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    'Missing required metadata for SWAIF automation.',
+                    '',
+                    'Please edit the issue body and provide values directly under:',
+                    '- `### Feature Slug`',
+                    '- `### Declared Execution Type`',
+                    '',
+                    'Then re-apply one stage label: `swaif:specify`, `swaif:plan`, `swaif:tasks`, `swaif:implement`, or `swaif:verify`.'
+                  ].join('\n')
+                });
+                core.setFailed('Issue metadata missing.');
+                return;
+              }
+            }
+
+            if (!allowedStages.has(stage)) {
+              core.setFailed(`Invalid stage '${stage}'. Must be exactly one of: specify, plan, tasks, implement, verify.`);
+              return;
+            }
+
+            if (!/^[a-z0-9][a-z0-9-]*$/.test(featureSlug)) {
+              core.setFailed(`Invalid feature_slug '${featureSlug}'. Expected kebab-case.`);
+              return;
+            }
+
+            core.setOutput('stage', stage);
+            core.setOutput('feature_slug', featureSlug);
+            core.setOutput('execution_type', executionType);
+            core.setOutput('issue_number', issueNumber);
+
+      - name: Run one SWAIF stage
+        run: |
+          ./scripts/swaif_stage.sh \
+            "${{ steps.meta.outputs.stage }}" \
+            "specs/${{ steps.meta.outputs.feature_slug }}" \
+            "${{ steps.meta.outputs.execution_type }}" \
+            "${{ steps.meta.outputs.issue_number }}"
+
+      - name: Create or update PR
+        uses: actions/github-script@v7
+        env:
+          FEATURE_SLUG: ${{ steps.meta.outputs.feature_slug }}
+          STAGE: ${{ steps.meta.outputs.stage }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = `${owner}:swaif/${process.env.FEATURE_SLUG}`;
+            const base = 'main';
+            const title = `SWAIF ${process.env.STAGE}: ${process.env.FEATURE_SLUG}`;
+            const body = [
+              'Automated SWAIF stage execution.',
+              '',
+              `- Stage: \\`${process.env.STAGE}\\``,
+              `- Feature: \\`${process.env.FEATURE_SLUG}\\``,
+              '',
+              'SWAIF is a Spec-Driven Software Factory where production is stage-gated (no vibe coding), traceable, and driven by a Kanban state machine—each Kanban move runs exactly one factory step, and failures block until fixed.'
+            ].join('\n');
+
+            const prs = await github.rest.pulls.list({ owner, repo, state: 'open', head, base });
+            if (prs.data.length > 0) {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prs.data[0].number,
+                title,
+                body
+              });
+            } else {
+              await github.rest.pulls.create({ owner, repo, head, base, title, body });
+            }
+
+      - name: On failure add blocked label and guidance
+        if: failure() && github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue) return;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['swaif:blocked']
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: [
+                'Factory step failed and issue was marked `swaif:blocked`.',
+                '',
+                'Next steps:',
+                '1. Review workflow logs for the failing stage.',
+                '2. Fix missing prerequisites or issue metadata.',
+                '3. Re-apply the intended stage label to re-run exactly one step.'
+              ].join('\n')
+            });

--- a/.swaif/COPILOT_ENTRYPOINT.md
+++ b/.swaif/COPILOT_ENTRYPOINT.md
@@ -1,0 +1,23 @@
+# SWAIF Copilot/Codex Entrypoint
+
+Follow these sources first:
+
+1. `.swaif/engine/agents/*`
+2. `.swaif/engine/templates/*`
+
+Do not skip stage gates. Run exactly one factory step per request.
+
+## Prompt patterns
+
+- **FIP validation**
+  - "Validate this Factory Input Package against SWAIF gate criteria and list gaps only."
+- **Spec generation**
+  - "Using `.swaif/engine/templates/swaif-spec-template.md`, generate `specs/<NNN-feature>/spec.md` from this FIP."
+- **Plan generation**
+  - "Given `spec.md`, generate `plan.md` using `.swaif/engine/templates/swaif-plan-template.md`."
+- **Tasks generation**
+  - "Given `plan.md`, generate `tasks.md` using `.swaif/engine/templates/swaif-tasks-template.md`."
+- **Implement**
+  - "Implement only tasks approved in `tasks.md`; do not introduce unplanned scope."
+- **Verify**
+  - "Verify completion against acceptance criteria and task traceability; report blockers deterministically."

--- a/.swaif/PROJECT_AUTOMATION.md
+++ b/.swaif/PROJECT_AUTOMATION.md
@@ -1,0 +1,25 @@
+# SWAIF Project Automation Mapping
+
+RepoName: <REPLACE_WITH_THIS_REPO_NAME>
+
+ProjectStatusFieldValues: <REPLACE_WITH_YOUR_PROJECT_STATUS_VALUES>
+
+## Exact Status -> Label mapping
+
+- Intake Ready -> (no stage label; ready for operator triage)
+- Specify In Progress -> `swaif:specify`
+- Plan In Progress -> `swaif:plan`
+- Tasks In Progress -> `swaif:tasks`
+- Implement In Progress -> `swaif:implement`
+- Verify -> `swaif:verify`
+- Done -> (no stage label; closeout state)
+- Blocked -> `swaif:blocked` (optional)
+
+## Operator loop
+
+1. Move card in Project to a stage status.
+2. Apply matching `swaif:*` label on the issue.
+3. Workflow runs exactly one SWAIF stage.
+4. Workflow updates/creates PR from `swaif/<feature-slug>` to `main`.
+5. If failed, workflow adds `swaif:blocked` and comments next steps.
+6. Operator fixes metadata/content and moves forward.

--- a/.swaif/engine/.specify/memory/constitution.md
+++ b/.swaif/engine/.specify/memory/constitution.md
@@ -1,0 +1,9 @@
+# Canonical Constitution
+
+This file is the canonical constitution path for the pinned SWAIF engine snapshot.
+
+If historical content exists in `swaif-constitution.md`, treat this file as the entrypoint and keep both synchronized.
+
+## Canonical source in this snapshot
+
+- `./swaif-constitution.md`

--- a/.swaif/engine/VERSION.txt
+++ b/.swaif/engine/VERSION.txt
@@ -1,0 +1,3 @@
+UNPINNED
+
+Pin this engine snapshot to the Docs Source of Truth (SoT) by replacing this value with an immutable tag or commit SHA from the Docs repository.

--- a/cases/README.md
+++ b/cases/README.md
@@ -1,1 +1,7 @@
+# cases/ (Deprecated)
 
+This directory is deprecated for production execution artifacts.
+
+Use `specs/<NNN-feature>/{spec.md, plan.md, tasks.md}` for production outputs so automation can run deterministic, stage-gated SWAIF flows.
+
+`cases/` is retained only for backward compatibility with older repository history.

--- a/scripts/swaif_stage.sh
+++ b/scripts/swaif_stage.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stage="${1:-}"
+feature_dir="${2:-}"
+execution_type="${3:-}"
+issue_number="${4:-}"
+
+if [[ -z "$stage" || -z "$feature_dir" || -z "$execution_type" || -z "$issue_number" ]]; then
+  echo "Usage: $0 <stage> <feature_dir> <execution_type> <issue_number>" >&2
+  exit 1
+fi
+
+case "$stage" in
+  specify|plan|tasks|implement|verify) ;;
+  *)
+    echo "Invalid stage: $stage" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$feature_dir" =~ ^specs/[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "feature_dir must match specs/<feature-slug> with kebab-case slug" >&2
+  exit 1
+fi
+
+feature_slug="${feature_dir#specs/}"
+branch="swaif/${feature_slug}"
+
+spec_file="${feature_dir}/spec.md"
+plan_file="${feature_dir}/plan.md"
+tasks_file="${feature_dir}/tasks.md"
+implement_marker="${feature_dir}/IMPLEMENT_PLACEHOLDER.txt"
+verify_marker="${feature_dir}/VERIFY_PLACEHOLDER.txt"
+
+mkdir -p "$feature_dir"
+
+git fetch origin "$branch" || true
+if git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+  git checkout -B "$branch" "origin/$branch"
+else
+  git checkout -B "$branch"
+fi
+
+create_if_missing() {
+  local target="$1"
+  local content="$2"
+  if [[ ! -f "$target" ]]; then
+    printf "%s\n" "$content" > "$target"
+  fi
+}
+
+case "$stage" in
+  specify)
+    create_if_missing "$spec_file" "# Spec: ${feature_slug}
+
+- Declared Execution Type: ${execution_type}
+- Issue: #${issue_number}
+
+## Problem
+_TODO_
+
+## Acceptance Criteria
+- [ ] AC-001 _TODO_
+"
+    ;;
+  plan)
+    [[ -f "$spec_file" ]] || { echo "Missing prerequisite: $spec_file" >&2; exit 1; }
+    create_if_missing "$plan_file" "# Plan: ${feature_slug}
+
+Derived from: spec.md
+
+## Approach
+_TODO_
+
+## Risks
+- _TODO_
+"
+    ;;
+  tasks)
+    [[ -f "$plan_file" ]] || { echo "Missing prerequisite: $plan_file" >&2; exit 1; }
+    create_if_missing "$tasks_file" "# Tasks: ${feature_slug}
+
+Derived from: plan.md
+
+- [ ] TASK-001 _TODO_
+"
+    ;;
+  implement)
+    [[ -f "$tasks_file" ]] || { echo "Missing prerequisite: $tasks_file" >&2; exit 1; }
+    create_if_missing "$implement_marker" "Implement stage placeholder for ${feature_slug}
+Issue: #${issue_number}
+"
+    ;;
+  verify)
+    [[ -f "$tasks_file" ]] || { echo "Missing prerequisite: $tasks_file" >&2; exit 1; }
+    create_if_missing "$verify_marker" "Verify stage placeholder for ${feature_slug}
+Issue: #${issue_number}
+"
+    ;;
+esac
+
+if git diff --quiet -- "$feature_dir"; then
+  echo "No changes to commit for stage '${stage}'."
+  exit 0
+fi
+
+git add "$feature_dir"
+git commit -m "swaif(${stage}): ${feature_slug} (issue #${issue_number})"
+git push -u origin "$branch"

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,19 @@
+# Specs Production Artifacts
+
+Production artifacts live under:
+
+- `specs/<NNN-feature>/spec.md`
+- `specs/<NNN-feature>/plan.md`
+- `specs/<NNN-feature>/tasks.md`
+
+## Stage-gated flow
+
+SWAIF execution is stage-gated and moves in this order:
+
+1. Specify
+2. Plan
+3. Tasks
+4. Implement
+5. Verify
+
+Each stage must complete before the next stage starts.


### PR DESCRIPTION
### Motivation

- Enforce SWAIF's stage-gated, spec-driven workflow by providing a deterministic SpecKit production layout and automation entrypoints. 
- Provide a canonical engine snapshot entry (constitution + pin placeholder) so engine snapshot/Docs SoT expectations are explicit. 
- Give Copilot/Codex a clear entrypoint and prompt patterns to ensure generated outputs follow stage gates and engine templates. 
- Enable Kanban-driven automation that runs exactly one factory stage per trigger and blocks on missing metadata or failures.

### Description

- Added `specs/README.md` and scaffolded the SpecKit production artifact locations `specs/<NNN-feature>/{spec.md, plan.md, tasks.md}` and stage-gated flow. 
- Marked `cases/` as deprecated for production by updating `cases/README.md` (kept folder for backward compatibility). 
- Created canonical constitution at `.swaif/engine/.specify/memory/constitution.md` while preserving existing constitution templates in the engine snapshot. 
- Added engine pin placeholder `.swaif/engine/VERSION.txt` containing `UNPINNED` and instructions to pin to the Docs SoT. 
- Added `.swaif/COPILOT_ENTRYPOINT.md` with prioritized sources and prompt patterns for FIP validation, spec/plan/tasks generation, implement, and verify steps. 
- Added `.swaif/PROJECT_AUTOMATION.md` documenting exact Status->label mapping (placeholders `RepoName` and `ProjectStatusFieldValues` left for repo owner) and the operator loop. 
- Replaced/created GitHub Actions workflow `.github/workflows/swaif-factory.yml` that triggers on issue label (`swaif:specify|plan|tasks|implement|verify`) and `workflow_dispatch`, parses issue body headings (`### Feature Slug`, `### Declared Execution Type`), enforces single-stage runs, comments and fails when metadata is missing, adds `swaif:blocked` on failure, and creates/updates a PR from `swaif/<feature-slug>` to `main`; the workflow uses `fetch-depth: 0`. 
- Added issue form `.github/ISSUE_TEMPLATE/swaif_feature.yml` with fields matching the parser and required headings. 
- Added `scripts/swaif_stage.sh`, a strict-mode, idempotent stage runner that enforces prereqs per stage, creates scaffolds (`spec.md`, `plan.md`, `tasks.md`, `IMPLEMENT_PLACEHOLDER.txt`, `VERIFY_PLACEHOLDER.txt`), uses branch `swaif/<feature-slug>`, commits and pushes changes, and avoids noisy changes on reruns. 

### Testing

- Ran a shell syntax check `bash -n scripts/swaif_stage.sh` and it returned OK. 
- Validated the workflow YAML by loading it via Ruby YAML (`YAML.load_file('.github/workflows/swaif-factory.yml')`) and it parsed successfully. 
- Performed existence/assertion checks in Python to confirm all created files exist (`specs/README.md`, `cases/README.md`, `.swaif/engine/.specify/memory/constitution.md`, `.swaif/engine/VERSION.txt`, `.swaif/COPILOT_ENTRYPOINT.md`, `.swaif/PROJECT_AUTOMATION.md`, `.github/ISSUE_TEMPLATE/swaif_feature.yml`, `.github/workflows/swaif-factory.yml`, `scripts/swaif_stage.sh`) and all checks passed. 
- Committed changes to a single focused commit and verified repository status; commit applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6992410cac348326817141bc3d3d8cc4)