### PR TITLE
swaif: add structured logging, robust stage runner, speckit command hints, and tests

### DIFF
--- a/.github/workflows/swaif-factory.yml
+++ b/.github/workflows/swaif-factory.yml
@@ -224,25 +224,43 @@ jobs:
           mkdir -p "$log_dir"
           log_file="${log_dir}/swaif-stage-${{ steps.meta.outputs.stage }}-issue-${{ steps.meta.outputs.issue_number }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}.log"
 
+          stage_script="./scripts/swaif_stage.sh"
+          stage_args=(
+            "${{ github.event.issue.title }}"
+            "${{ steps.meta.outputs.stage }}"
+            "specs/${{ steps.meta.outputs.feature_slug }}"
+            "${{ steps.meta.outputs.execution_type }}"
+            "${{ steps.meta.outputs.issue_number }}"
+          )
+
           {
             echo "=== SWAIF Stage Execution Log ==="
             echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "repo=${{ github.repository }}"
             echo "run_id=${{ github.run_id }}"
             echo "run_attempt=${{ github.run_attempt }}"
+            echo "workflow=${{ github.workflow }}"
+            echo "event_name=${{ github.event_name }}"
+            echo "actor=${{ github.actor }}"
+            echo "ref=${{ github.ref }}"
+            echo "sha=${{ github.sha }}"
             echo "issue_number=${{ steps.meta.outputs.issue_number }}"
             echo "stage=${{ steps.meta.outputs.stage }}"
             echo "feature_slug=${{ steps.meta.outputs.feature_slug }}"
             echo "execution_type=${{ steps.meta.outputs.execution_type }}"
+            echo "current_branch=$(git rev-parse --abbrev-ref HEAD)"
+            echo "current_commit=$(git rev-parse --short HEAD)"
+            echo "script_path=${stage_script}"
+            printf 'script_args=%q %q %q %q %q\n' "${stage_args[@]}"
+            echo "SWAIF_DEBUG_LOG=${log_file}"
+            echo "SWAIF_TRACE_COMMANDS=1"
             echo
             export OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
-            ./scripts/swaif_stage.sh \
-              "${{ github.event.issue.title }}" \
-              "${{ steps.meta.outputs.stage }}" \
-              "specs/${{ steps.meta.outputs.feature_slug }}" \
-              "${{ steps.meta.outputs.execution_type }}" \
-              "${{ steps.meta.outputs.issue_number }}"
+            export SWAIF_DEBUG_LOG="$log_file"
+            export SWAIF_TRACE_COMMANDS=1
+            "$stage_script" "${stage_args[@]}"
           } 2>&1 | tee -a "$log_file"
+
 
       - name: Upload SWAIF stage logs
         if: always()
@@ -356,12 +374,29 @@ jobs:
               specify: '📋', plan: '🗺️', tasks: '✅',
               implement: '⚙️', verify: '🔍'
             };
+            const stageSpeckitCommand = {
+              specify: '/speckit.specify specs/<feature-slug>/intake.md',
+              plan: '/speckit.plan specs/<feature-slug>/spec.md',
+              tasks: '/speckit.tasks specs/<feature-slug>/plan.md',
+              implement: '/speckit.implement specs/<feature-slug>/tasks.md',
+              verify: '/speckit.checklist specs/<feature-slug>/tasks.md'
+            };
             const nextStage = {
               init: 'specify', specify: 'plan', plan: 'tasks', tasks: 'implement',
               implement: 'verify', verify: null
             };
             const emoji = stageEmoji[stage] || '🚀';
             const next = nextStage[stage];
+            const commandTemplate = stageSpeckitCommand[stage] || null;
+            const commandBlock = commandTemplate
+              ? [
+                  `### Speckit command for \`swaif:${stage}\``,
+                  '',
+                  '```bash',
+                  commandTemplate.replace('<feature-slug>', featureSlug),
+                  '```'
+                ].join('\n')
+              : null;
             const nextLine = next
               ? `➡️ **Next:** Apply \`swaif:${next}\` to continue.`
               : '🎉 **All stages complete!** The feature is ready for final review.';
@@ -372,6 +407,7 @@ jobs:
               body: [
                 `${emoji} **SWAIF stage \`${stage}\` completed successfully** for \`${featureSlug}\`.`,
                 '',
+                ...(commandBlock ? [commandBlock, ''] : []),
                 nextLine,
                 '',
                 '<details><summary>Available stage labels</summary>',
@@ -538,7 +574,7 @@ jobs:
               console.log(`Project board update failed (non-fatal): ${err.message}`);
             }
 
-      - name: On failure add blocked label and guidance
+      - name: On failure set issue label to blocked
         if: failure() && github.event_name == 'issues'
         uses: actions/github-script@v7
         with:
@@ -547,18 +583,40 @@ jobs:
             const issue = context.payload.issue;
             const logsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             if (!issue) return;
+
+            const stageLabels = [
+              'swaif:init', 'swaif:specify', 'swaif:plan', 'swaif:tasks',
+              'swaif:implement', 'swaif:verify', 'swaif:blocked'
+            ];
+            const existing = issue.labels.map((l) => l.name);
+
+            for (const label of stageLabels) {
+              if (!existing.includes(label)) continue;
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: label
+                });
+              } catch (err) {
+                console.log(`Could not remove label '${label}': ${err.message}`);
+              }
+            }
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
               labels: ['swaif:blocked']
             });
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
               body: [
-                '🚫 **SWAIF stage failed** — issue marked `swaif:blocked`.',
+                '🚫 **SWAIF stage failed** — current stage label removed and issue marked `swaif:blocked`.',
                 '',
                 '**Next steps:**',
                 `1. 🔍 Review the [workflow logs](${logsUrl}) to identify the root cause.`,

--- a/scripts/tests/test_swaif_stage.sh
+++ b/scripts/tests/test_swaif_stage.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/scripts/swaif_stage.sh"
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; exit 1; }
+
+setup_repo() {
+  local dir="$1"
+  git init -q "$dir"
+  (
+    cd "$dir"
+    git config user.name tester
+    git config user.email tester@example.com
+    mkdir -p specs
+    echo "seed" > README.md
+    git add README.md
+    git commit -qm "init"
+  )
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -F "$needle" "$file" >/dev/null || fail "expected '$needle' in $file"
+}
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Test 1: failure mechanism coverage (missing spec for plan)
+FAIL_REPO="$TMPDIR/failure-repo"
+setup_repo "$FAIL_REPO"
+mkdir -p "$FAIL_REPO/specs/feature-a"
+cat > "$FAIL_REPO/specs/feature-a/intake.md" <<TXT
+Intake ok
+TXT
+
+set +e
+(
+  cd "$FAIL_REPO"
+  SWAIF_TEST_MODE=1 "$SCRIPT" "Issue" "plan" "specs/feature-a" "manual" "1" >out.log 2>err.log
+)
+CODE=$?
+set -e
+[[ $CODE -ne 0 ]] || fail "plan should fail when spec.md is missing"
+grep -F "[ERROR] [PREREQUISITE]" "$FAIL_REPO/err.log" >/dev/null || fail "missing categorized prerequisite error"
+pass "failure path categorization"
+
+# Test 2: common flow (specify -> plan -> tasks -> implement -> verify)
+OK_REPO="$TMPDIR/ok-repo"
+setup_repo "$OK_REPO"
+mkdir -p "$OK_REPO/specs/feature-b"
+cat > "$OK_REPO/specs/feature-b/intake.md" <<TXT
+Intake baseline
+TXT
+
+(
+  cd "$OK_REPO"
+  SWAIF_TEST_MODE=1 "$SCRIPT" "Issue" "specify" "specs/feature-b" "manual" "2"
+  SWAIF_TEST_MODE=1 "$SCRIPT" "Issue" "plan" "specs/feature-b" "manual" "2"
+  SWAIF_TEST_MODE=1 "$SCRIPT" "Issue" "tasks" "specs/feature-b" "manual" "2"
+  SWAIF_TEST_MODE=1 "$SCRIPT" "Issue" "implement" "specs/feature-b" "manual" "2"
+  SWAIF_TEST_MODE=1 "$SCRIPT" "Issue" "verify" "specs/feature-b" "manual" "2"
+)
+
+assert_file_contains "$OK_REPO/specs/feature-b/spec.md" "/speckit.specify specs/feature-b/intake.md"
+assert_file_contains "$OK_REPO/specs/feature-b/plan.md" "/speckit.plan specs/feature-b/spec.md"
+assert_file_contains "$OK_REPO/specs/feature-b/tasks.md" "/speckit.tasks specs/feature-b/plan.md"
+assert_file_contains "$OK_REPO/specs/feature-b/IMPLEMENT_PLACEHOLDER.txt" "/speckit.implement specs/feature-b/tasks.md"
+assert_file_contains "$OK_REPO/specs/feature-b/VERIFY_PLACEHOLDER.txt" "/speckit.checklist specs/feature-b/tasks.md"
+pass "common flow artifact generation"
+
+echo "All tests passed"


### PR DESCRIPTION
### Motivation

- Improve observability and reliability of the SWAIF stage runner so failures are easier to diagnose and stages are more robustly enforced.
- Provide actionable Speckit command hints in issue comments to make it easier to re-run or continue stages.
- Add a test harness to validate common flows and failure modes without network calls.

### Description

- Enhance the workflow step that invokes the stage runner to set `stage_script`/`stage_args`, export `SWAIF_DEBUG_LOG` and `SWAIF_TRACE_COMMANDS`, and log rich context (workflow, event, actor, ref/sha, branch/commit, script path and args) before running the script. 
- Add per-stage Speckit command templates to the success comment so issue comments include a runnable `speckit` command block for the completed stage. 
- On failure, ensure any existing swaif stage labels are removed before adding `swaif:blocked` and update the failure comment to reflect this behavior. 
- Refactor `scripts/swaif_stage.sh` into a structured script with diagnostics and helpers, including: `fail_with` and categorized logging, command tracing, `SWAIF_TEST_MODE` to skip network/git side effects in tests, `sync_branch_state`, `resolve_constitution_file`, `ensure_required_stage_files`, `speckit_command_for_stage`, `stage_template_with_speckit_block`, `bootstrap_speckit_agent_context`, `customize_speckit_agent_context`, `run_stage`, `finalize_commit`, and `main` orchestration. 
- Replace inline stage actions with templated file generation that inserts a Speckit command block for each artifact (`spec.md`, `plan.md`, `tasks.md`, placeholders). 
- Improve git handling: log git context, set git identity for CI commits, and only commit when there are changes. 
- Add a test script `scripts/tests/test_swaif_stage.sh` that initializes ephemeral repos and exercises failure and full-stage flows using `SWAIF_TEST_MODE=1` to avoid external dependencies.

### Testing

- Ran the new test harness `scripts/tests/test_swaif_stage.sh`, which executes a missing-prerequisite failure scenario and a full specify→plan→tasks→implement→verify flow, and the script completed with all assertions passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699fac01cc78832685da455eac970c00)